### PR TITLE
Define unamer helper to fix Windows build

### DIFF
--- a/build_oc.tool
+++ b/build_oc.tool
@@ -5,6 +5,16 @@ abort() {
   exit 1
 }
 
+unamer() {
+  NAME="$(uname)"
+  if [ "$(echo "${NAME}" | grep MINGW)" != "" ] || \
+     [ "$(echo "${NAME}" | grep MSYS)" != "" ]; then
+    echo "Windows"
+  else
+    echo "${NAME}"
+  fi
+}
+
 buildutil() {
   UTILS=(
     "AppleEfiSignTool"


### PR DESCRIPTION
## Summary
- add `unamer` helper function to normalize uname output
- use the helper when checking for Windows OS

## Testing
- `bash -n build_oc.tool`

------
https://chatgpt.com/codex/tasks/task_e_68447ce35f08832895f6f0d5a55edeca