### PR TITLE
Document unamer helper in build_oc.tool

### DIFF
--- a/build_oc.tool
+++ b/build_oc.tool
@@ -5,6 +5,13 @@ abort() {
   exit 1
 }
 
+##
+# unamer
+#
+# Wrapper around `uname` that reports `Windows` when using MINGW or MSYS
+# environments. This helper allows build_oc.tool to work consistently on
+# Windows hosts while continuing to return the regular `uname` result for
+# other platforms.
 unamer() {
   NAME="$(uname)"
   if echo "${NAME}" | grep -qE 'MINGW|MSYS'; then


### PR DESCRIPTION
## Summary
- document the `unamer()` helper in `build_oc.tool` so the intent is clear

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684482dd28e88328af4e134c0c8a16e1