### PR TITLE
Add documentation index

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,0 +1,27 @@
+# OpenCore Documentation
+
+This directory contains reference manuals, sample configuration files, and other useful resources.
+
+## Major documents
+
+- **Configuration.pdf** – comprehensive reference manual describing all OpenCore configuration options.
+- **Differences/Differences.pdf** – highlights configuration changes between releases.
+- **Errata/Errata.pdf** – errata sheet with clarifications and known issues in the manual.
+- **Kexts.md** – list of commonly used kernel extensions.
+- **Flavours.md** – overview of the OpenCore content flavour naming scheme used for icons.
+- **Libraries.md** – brief description of the libraries included in this package.
+- **FORUMS.md** – links to community forums for discussion and support.
+- **Sample.plist** – minimal sample configuration file.
+- **SampleCustom.plist** – alternative sample configuration with additional settings.
+- **AcpiSamples/Source/** – collection of example ACPI tables.
+- **Logos/** – official project logos.
+
+## Rebuilding documentation
+
+PDF manuals such as `Configuration.pdf`, `Differences.pdf` and `Errata.pdf` can be rebuilt using:
+
+```bash
+./Docs/BuildDocs.tool
+```
+
+A complete TeX Live installation with `pdflatex` and `latexdiff` is required.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ details.
 - [usr-sse2](https://github.com/usr-sse2)
 - [vit9696](https://github.com/vit9696)
 
+#### Documentation
+
+See the [documentation index](Docs/README.md) for a list of manuals and example files.
+
 #### Discussion
 
 Please refer to the following [list of OpenCore discussion forums](/Docs/FORUMS.md).


### PR DESCRIPTION
## Summary
- add `Docs/README.md` to list main docs and describe how to rebuild them
- link to the new docs index from the project README

## Testing
- `./Docs/BuildDocs.tool --check-docs` *(fails: latexdiff missing)*
- `./build_oc.tool --skip-build --skip-package` *(fails: curl 403)*

------
https://chatgpt.com/codex/tasks/task_e_684482db02f883288b6c07026e4198bf

## Summary by Sourcery

Add a central documentation index under Docs, link it from the main README, and provide instructions for rebuilding PDF manuals

Documentation:
- Introduce Docs/README.md to list major manuals, sample configuration files, ACPI examples, and project assets
- Outline how to rebuild PDF documentation using BuildDocs.tool with a full TeX Live installation
- Update the project README to include a link to the new documentation index