### PR TITLE
Add build documentation

### DIFF
--- a/Docs/BUILDING.md
+++ b/Docs/BUILDING.md
@@ -1,0 +1,34 @@
+# Building OpenCorePkg
+
+This document outlines the recommended environment and steps required to build OpenCorePkg and its documentation.
+
+## Prerequisites
+
+- macOS with the latest **Xcode** installed. The XCODE5 toolchain is used.
+- [**NASM**](https://www.nasm.us)
+- [**MTOC** and **mtoc.NEW**](https://github.com/acidanthera/ocbuild/tree/master/external)
+- For documentation: a TeX Live installation providing `pdflatex` and `latexdiff`.
+
+## Building OpenCore
+
+From the repository root run:
+
+```bash
+./build_oc.tool
+```
+
+This invokes the EDK II build system and produces packages in the `Binaries` directory. Additional options are available via `./build_oc.tool --help`.
+
+## Building the Documentation
+
+To generate `Configuration.pdf` and related files run:
+
+```bash
+./Docs/BuildDocs.tool
+```
+
+Make sure the TeX prerequisites listed above are installed.
+
+## `unamer()` helper
+
+`build_oc.tool` defines a helper called `unamer()` which wraps `uname`. On Windows MSYS or MINGW shells `uname` returns strings like `MINGW64_NT-10.0`. The helper normalises this output to simply `Windows` so the script can detect the host platform reliably.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ details.
 #### Discussion
 
 Please refer to the following [list of OpenCore discussion forums](/Docs/FORUMS.md).
+
+#### Building
+
+Instructions for setting up the build environment and using the helper scripts can
+be found in [BUILDING.md](Docs/BUILDING.md).


### PR DESCRIPTION
## Summary
- document prerequisites for building OpenCorePkg
- explain how to run `build_oc.tool` and `Docs/BuildDocs.tool`
- describe the `unamer()` helper
- link BUILDING.md from README

## Testing
- `./build_oc.tool --help` *(fails: curl 403)*
- `./Docs/BuildDocs.tool -h` *(fails: latexdiff missing)*

------
https://chatgpt.com/codex/tasks/task_e_684482d80ec8832883ae5432c373afb7

## Summary by Sourcery

Add a new BUILDING.md guide and link it in the README to document the build environment, build scripts, and helper functions.

Documentation:
- Add BUILDING.md detailing prerequisites and steps to build OpenCorePkg and its documentation
- Explain usage of build_oc.tool and Docs/BuildDocs.tool with available options
- Describe the unamer() helper for consistent platform detection
- Link BUILDING.md from the README under a new "Building" section