### PR TITLE
Pin ocbuild downloads

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: CI Bootstrap
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh) && eval "$src" || exit 1
 
       - name: Run shellcheck
         run: find . \( -name "*.tool" -o -name "*.command" -o -name "*.sh" \) -exec sh -c 'for TargetFile; do shellcheck --severity=info "${TargetFile}" || exit 1; done' sh {} +
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run prospector
         run: |
-          /usr/bin/curl -L https://raw.githubusercontent.com/acidanthera/ocbuild/master/prospector/profile.yml -o profile.yml || exit 1
+          /usr/bin/curl -L https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/prospector/profile.yml -o profile.yml || exit 1
           python3 -m prospector . -P ./profile.yml | tee prospector_result.txt || exit 1
 
       - name: Upload prospector result to Artifacts
@@ -118,14 +118,14 @@ jobs:
 
       - name: CI Bootstrap
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh) && eval "$src" || exit 1
 
       - run: ./build_oc.tool --skip-build --skip-package
 
       - name: Run Coverity
         working-directory: UDK
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/coverity/covstrap-linux.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/coverity/covstrap-linux.sh) && eval "$src" || exit 1
         env:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: CI Bootstrap
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh) && eval "$src" || exit 1
 
       - run: ./build_duet.tool
       - run: ./build_oc.tool
@@ -64,7 +64,7 @@ jobs:
 
       - name: Apply Docker AppArmor settings
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/docker-apparmor.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/docker-apparmor.sh) && eval "$src" || exit 1
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -91,7 +91,7 @@ jobs:
 
       - name: Apply Docker AppArmor settings
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/docker-apparmor.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/docker-apparmor.sh) && eval "$src" || exit 1
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -118,7 +118,7 @@ jobs:
 
       - name: Apply Docker AppArmor settings
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/docker-apparmor.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/docker-apparmor.sh) && eval "$src" || exit 1
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -143,7 +143,7 @@ jobs:
 
       - name: Apply Docker AppArmor settings
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/docker-apparmor.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/docker-apparmor.sh) && eval "$src" || exit 1
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -169,7 +169,7 @@ jobs:
 
       - name: CI Bootstrap
         run: |
-          src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh) && eval "$src" || exit 1
 
       - run: ./build_duet.tool
       - run: ./build_oc.tool

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -25,11 +25,11 @@ jobs:
 
       - name: CI Bootstrap
         run: |
-          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh) && eval "$src" || exit 1
 
       - name: Run Uncrustify
         run: |
-          python3 -c "$(/usr/bin/curl https://raw.githubusercontent.com/acidanthera/ocbuild/master/uncstrap/uncstrap.py)" ./Uncrustify.yml || exit 1
+          python3 -c "$(/usr/bin/curl https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/uncstrap/uncstrap.py)" ./Uncrustify.yml || exit 1
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v4

--- a/build_duet.tool
+++ b/build_duet.tool
@@ -198,5 +198,5 @@ else
   export SELFPKG
   export NO_ARCHIVES
 
-  src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/efibuild.sh) && eval "$src" || exit 1
+  src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/efibuild.sh) && eval "$src" || exit 1
 fi

--- a/build_oc.tool
+++ b/build_oc.tool
@@ -418,7 +418,7 @@ export SELFPKG
 export NO_ARCHIVES
 export DISCARD_SUBMODULES
 
-src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/efibuild.sh) && eval "$src" || exit 1
+src=$(curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/efibuild.sh) && eval "$src" || exit 1
 
 cd Utilities/ocvalidate || exit 1
 ocv_tool=""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,14 +30,14 @@ services:
     entrypoint:
       - /bin/bash
       - -c
-      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh)\" && ./build_oc.tool ; } || exit 1"
+      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh)\" && ./build_oc.tool ; } || exit 1"
   build-duet:
     extends:
       service: dev-edk2
     entrypoint:
       - /bin/bash
       - -c
-      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh)\" && ./build_duet.tool ; } || exit 1"
+      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -LfsS https://raw.githubusercontent.com/acidanthera/ocbuild/58c7fa9038f671814effdae3d01645a7dccb1819/ci-bootstrap.sh)\" && ./build_duet.tool ; } || exit 1"
   build-docs:
     extends:
       service: dev-docs


### PR DESCRIPTION
## Summary
- pin ocbuild script locations to a specific commit SHA
- use pinned URLs in docker-compose and all workflows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f0e19a3408328993b2dcf3378a900

## Summary by Sourcery

Pin ocbuild external script and resource downloads to a specific commit SHA for reproducible builds.

Enhancements:
- Pin all ocbuild script URLs in GitHub Actions workflows to commit 58c7fa9… for CI consistency

Chores:
- Update docker-compose commands to fetch ci-bootstrap.sh from the pinned ocbuild commit