### PR TITLE
Add contribution and community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) Code of Conduct.
+
+All community members are expected to be respectful and considerate. Unacceptable behavior should be reported via the issue tracker or privately to the maintainers.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for your interest in OpenCorePkg. This document covers the basics of building the project, running tests, and submitting pull requests.
+
+## Building
+
+OpenCorePkg uses the EDK II build system. A macOS host with Xcode and the tools listed in [Docs/BUILDING.md](Docs/BUILDING.md) is recommended.
+
+From the repository root run:
+
+```bash
+./build_oc.tool
+```
+
+This script builds OpenCorePkg and the utility tools. Extra options are available via `./build_oc.tool --help`.
+
+## Running tests
+
+The `Tests` directory contains several EDK II applications. To build a specific test run:
+
+```bash
+make -C Tests/<TestName>
+```
+
+The tests are EFI binaries that can be executed in a UEFI environment or virtual machine. Some tests are also built automatically when running `./build_oc.tool`.
+
+## Submitting pull requests
+
+1. Fork the repository and create a topic branch for your changes.
+2. Ensure the project builds and tests run without errors.
+3. Open a pull request against the `master` branch describing your changes in detail.
+4. By contributing you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+

--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ Please refer to the following [list of OpenCore discussion forums](/Docs/FORUMS.
 
 Instructions for setting up the build environment and using the helper scripts can
 be found in [BUILDING.md](Docs/BUILDING.md).
+
+#### Contributing
+
+Guidelines for building from source, running tests and submitting pull requests
+are available in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+#### Code of Conduct
+
+This project adheres to the [Contributor Covenant](CODE_OF_CONDUCT.md). Please
+read it before participating.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING instructions
- add a simple code of conduct referencing Contributor Covenant
- link these new docs from README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f0e2655108328844eb34a47b42cc5